### PR TITLE
chore(ENG-41061): remove msk lifecycle that ignores setting the broke…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -216,13 +216,6 @@ resource "aws_msk_cluster" "default" {
     }
   }
 
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to ebs_volume_size in favor of autoscaling policy
-      broker_node_group_info[0].storage_info[0].ebs_storage_info[0].volume_size,
-    ]
-  }
-
   tags = module.this.tags
 }
 


### PR DESCRIPTION
Remove the lifecycle section that ignores setting the storage volume, that way we can explicitly set the MSK storage size in addition to auto scaling capability.